### PR TITLE
Trim whitespace only Text Nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,9 @@ node_modules
 # Users Environment Variables
 .lock-wscript
 
+
+###MacOS###
+
+.DS_Store
+
 /dist

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Interpolate DOM Nodes into ES2015 Template Strings",
   "main": "dist/dom-template-strings.js",
   "scripts": {
-    "build": "babel src/index.js --presets es2015 -o dist/dom-template-strings.js",
+    "build": "mkdir -p ./dist && babel src/index.js --presets es2015 -o dist/dom-template-strings.js",
     "prepublish": "npm run build",
     "mocha": "mocha -r jsdom-global/register",
     "karma": "karma start ./karma.conf.js",

--- a/src/index.js
+++ b/src/index.js
@@ -16,14 +16,18 @@ function generateId () {
   return `p-${counter}-${Date.now()}`
 }
 
-function trim(node){
+/**
+ * Receives a DOM Fragment and trim out whitespace-only children TextNodes
+ * @param  {DocumentFragment} fragment   A DOM Fragment whose children will be trimmed
+ * @return {Node}                        A DOM Node 
+ */
+function trim(fragment){
   const outerWhitespaceNodeReducer = ({isLastOuterTextNodeFound, whitespaceNodes}, currentNode) => {
     if(isLastOuterTextNodeFound){
       return {isLastOuterTextNodeFound: true, whitespaceNodes}
     } else {
       if(currentNode.nodeType === Node.TEXT_NODE){
         if(currentNode.textContent.replace(/^\s+/, "")){
-          currentNode.textContent = currentNode.textContent.replace(/^\s+/, "")
           return {isLastOuterTextNodeFound: true, whitespaceNodes}
         } else {
           whitespaceNodes.push(currentNode)
@@ -35,7 +39,7 @@ function trim(node){
     }
   }
 
-  const {whitespaceNodes: leftWhiteSpaceNodes} = [...node.childNodes].reduce(
+  const {whitespaceNodes: leftWhiteSpaceNodes} = [...fragment.childNodes].reduce(
     outerWhitespaceNodeReducer
     ,{
       isLastOuterTextNodeFound: false
@@ -43,7 +47,7 @@ function trim(node){
     }
   )
 
-  const {whitespaceNodes: rightWhiteSpaceNodes} = [...node.childNodes].reduceRight(
+  const {whitespaceNodes: rightWhiteSpaceNodes} = [...fragment.childNodes].reduceRight(
     outerWhitespaceNodeReducer
     ,{
       isLastOuterTextNodeFound: false
@@ -54,12 +58,12 @@ function trim(node){
   if(leftWhiteSpaceNodes.length) leftWhiteSpaceNodes.forEach(node => node.remove())
   if(rightWhiteSpaceNodes.length) rightWhiteSpaceNodes.forEach(node => node.remove())
   
-  if (node.childNodes.length == 1) {
-    let child = node.firstChild
-    node.removeChild(child)
+  if (fragment.childNodes.length == 1) {
+    let child = fragment.firstChild
+    fragment.removeChild(child)
     return child
   } else {
-    return node
+    return fragment
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -17,36 +17,36 @@ function generateId () {
 }
 
 function trim(node){
-  const outterWhitespaceNodeReducer = ({isLastOutterTextNodeFound, whitespaceNodes}, currentNode) => {
-    if(isLastOutterTextNodeFound){
-      return {isLastOutterTextNodeFound: true, whitespaceNodes}
+  const outerWhitespaceNodeReducer = ({isLastOuterTextNodeFound, whitespaceNodes}, currentNode) => {
+    if(isLastOuterTextNodeFound){
+      return {isLastOuterTextNodeFound: true, whitespaceNodes}
     } else {
       if(currentNode.nodeType === Node.TEXT_NODE){
         if(currentNode.textContent.replace(/^\s+/, "")){
           currentNode.textContent = currentNode.textContent.replace(/^\s+/, "")
-          return {isLastOutterTextNodeFound: true, whitespaceNodes}
+          return {isLastOuterTextNodeFound: true, whitespaceNodes}
         } else {
           whitespaceNodes.push(currentNode)
-          return {isLastOutterTextNodeFound: false, whitespaceNodes}
+          return {isLastOuterTextNodeFound: false, whitespaceNodes}
         }
       } else {
-        return {isLastOutterTextNodeFound: true, whitespaceNodes}
+        return {isLastOuterTextNodeFound: true, whitespaceNodes}
       }
     }
   }
 
   const {whitespaceNodes: leftWhiteSpaceNodes} = [...node.childNodes].reduce(
-    outterWhitespaceNodeReducer
+    outerWhitespaceNodeReducer
     ,{
-      isLastOutterTextNodeFound: false
+      isLastOuterTextNodeFound: false
       ,whitespaceNodes: []
     }
   )
 
   const {whitespaceNodes: rightWhiteSpaceNodes} = [...node.childNodes].reduceRight(
-    outterWhitespaceNodeReducer
+    outerWhitespaceNodeReducer
     ,{
-      isLastOutterTextNodeFound: false
+      isLastOuterTextNodeFound: false
       ,whitespaceNodes: []
     }
   )

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,39 @@ function generateId () {
   return `p-${counter}-${Date.now()}`
 }
 
+function trim(doc, node){
+
+  const intialWhitespaceNodeReducer = (isLastOutterTextNodeFound, currentNode) => {
+    if(isLastOutterTextNodeFound){
+      return true
+    } else {
+      if(currentNode.nodeType === Node.TEXT_NODE){
+        if(currentNode.textContent.replace(/^\s+/, "")){
+          currentNode.textContent = currentNode.textContent.replace(/^\s+/, "")
+          return true
+        } else {
+          currentNode.remove()
+          return false
+        }
+      } else {
+        isLastOutterTextNodeFound = true
+        return true
+      }
+    }
+  }
+
+  const trimmedLeft = [...node.childNodes].reduce(intialWhitespaceNodeReducer, false)
+  const trimmedRight = [...node.childNodes].reduceRight(intialWhitespaceNodeReducer, false)
+  
+  if (node.childNodes.length == 1) {
+    let child = node.firstChild
+    node.removeChild(child)
+    return child
+  } else {
+    return node
+  }
+}
+
 /**
  * Generates an array of DOM Nodes
  * @param  {...any} partials   Might be anything. DOM Nodes are handled, arrays are iterated over and then handled, everything else just gets passed through
@@ -53,9 +86,7 @@ function generateNodes (doc, ...partials) {
     const placeholder = container.querySelector(`${node.nodeName}#${id}`)
     placeholder.parentNode.replaceChild(node, placeholder)
   })
-
-  // Get array of Nodes
-  return container
+  return trim(doc, container)
 }
 
 /**
@@ -81,14 +112,7 @@ function domify (strings, ...values) {
     if (this.nodeType == Node.DOCUMENT_NODE) doc = this
     else if (this.ownerDocument) doc = this.ownerDocument
   }
-  let result = taggedTemplateHandler(doc, strings, ...values)
-  if (result.childNodes.length == 1) {
-    let child = result.firstChild
-    result.removeChild(child)
-    return child
-  } else {
-    return result
-  }
+  return taggedTemplateHandler(doc, strings, ...values)
 }
 
 })()

--- a/test/basic.js
+++ b/test/basic.js
@@ -101,9 +101,10 @@ describe('dom tagged template string', function() {
     
     assert.ok(node instanceof Node)
     assert.equal(node.nodeType, Node.DOCUMENT_FRAGMENT_NODE)
+    assert.equal(node.childNodes.length, 2)
   })
 
-  it('should remove whitespace chars around template', function() {
+  it('should not remove whitespace chars mixed with non-whitespace chars around template', function() {
     let node = dom`
       
       Hello
@@ -112,12 +113,19 @@ describe('dom tagged template string', function() {
         content
       </div>
 
+      Bye
+
 
     `
+
+    const firstTextNodeContent = String.raw`${node.childNodes[0].textContent}`
+    const lastTextNodeContent = String.raw`${node.childNodes[2].textContent}`
     
     assert.ok(node instanceof Node)
     assert.equal(node.nodeType, Node.DOCUMENT_FRAGMENT_NODE)
-    assert.equal(node.childNodes.length, 2)
+    assert.equal(node.childNodes.length, 3)
+    assert.equal(firstTextNodeContent, `\n      \n      Hello\n      \n      `)
+    assert.equal(lastTextNodeContent, `\n\n      Bye\n\n\n    `)
   })
 })
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -75,6 +75,7 @@ describe('dom tagged template string', function() {
   it('should return a DOM Element when ther is only whitespace chars around template', function() {
     let node = dom`
   
+    
       <div>
         content
       </div>

--- a/test/basic.js
+++ b/test/basic.js
@@ -71,5 +71,52 @@ describe('dom tagged template string', function() {
     assert.equal(list.querySelectorAll('li').length, 3)
     assert.equal(list.textContent, 'OneTwoThree')
   })
+
+  it('should return a DOM Element when ther is only whitespace chars around template', function() {
+    let node = dom`
+  
+      <div>
+        content
+      </div>
+
+
+    `
+    
+    assert.ok(node instanceof Node)
+    assert.equal(node.nodeType, Node.ELEMENT_NODE)
+  })
+
+  it('should return a DOM Fragment when there is non-whitespace chars around template', function() {
+    let node = dom`
+      
+      Hello
+      
+      <div>
+        content
+      </div>
+
+
+    `
+    
+    assert.ok(node instanceof Node)
+    assert.equal(node.nodeType, Node.DOCUMENT_FRAGMENT_NODE)
+  })
+
+  it('should remove whitespace chars around template', function() {
+    let node = dom`
+      
+      Hello
+      
+      <div>
+        content
+      </div>
+
+
+    `
+    
+    assert.ok(node instanceof Node)
+    assert.equal(node.nodeType, Node.DOCUMENT_FRAGMENT_NODE)
+    assert.equal(node.childNodes.length, 2)
+  })
 })
 


### PR DESCRIPTION
When creating a complex DOM element it would be great if one could  indent the code like the following and have an Element node as a result

```javascript
const $element = document.dom`
    <div>
        <div class="player player--1 ">
            <button class="player-btn player-btn--1">
                <span>!</span>
            </button>
            <div class="player-shadow"></div>
        </div>

        <div class="pontos">
            <div class="startOnePlayer pontos-barra pontos-barra--left">1 Player</div>
            <div class="startTwoPlayers pontos-barra--right">2 players</div>
        </div>

        <nav class="navigation">
            <figure class="navigation-item navigation-item--online">
                <img class="startOnePlayer" src="img/online.png">
            </figure>

            <figure class="navigation-item navigation-item--offline">
                <img class="startTwoPlayers" src="img/offline.png">
            </figure>
        </nav>
    </div>
`
```

Current implementation creates a TextNode for whitespace chars before an ElementNode. As a result, the constant `$element` is a Document Fragment and not an Element. That makes things like adding Event Listeners cumbersome. After this pull request `const $element` would be a Element Node and event listeners could be attached directly.

This pull-request code trim whitespace only Text Nodes out of the result. Text Nodes containing non-whitespace chars are maintained intact (any other kind of Node too). The following code would still result in a Document Fragment containing a Text Node and an Element Node.

```
Some tex here

<div>

</div>
```

Test cases where added.